### PR TITLE
fix: Merge nested browser window options instead of replacing them

### DIFF
--- a/electron-core/src/electron/CapacitorElectronApp.ts
+++ b/electron-core/src/electron/CapacitorElectronApp.ts
@@ -222,9 +222,9 @@ export class CapacitorElectronApp {
     };
 
     this.mainWindowReference = new BrowserWindow(
-      Object.assign(
+      deepMerge(
         this.config.mainWindow.windowOptions,
-        neededBrowserWindowConfig
+        [neededBrowserWindowConfig]
       )
     );
 

--- a/electron-core/src/plugins/electron/device.ts
+++ b/electron-core/src/plugins/electron/device.ts
@@ -23,6 +23,8 @@ export class DevicePluginElectron extends WebPlugin implements DevicePlugin {
     var info = await webDevice.getInfo();
 
     return {
+      appId: info.appId,
+      appName: info.appName,
       model: info.model,
       platform: <"electron">"electron",
       appVersion: app.getVersion(),


### PR DESCRIPTION
`Object.assign` doesn't merge deep objects so I couldn't customize nested options in `mainWindow.windowOptions` (e.g. `webPreferences`). This change fixes this.

Edit: The changes in `device.ts` are not related to the bug but somehow the build failed and this fixed it but the build doesn't use the last commit somehow?