### PR TITLE
`will-finish-launching` prevents deep linking from working on MacOS.

### DIFF
--- a/packages/core/src/electron/ElectronDeepLinking.ts
+++ b/packages/core/src/electron/ElectronDeepLinking.ts
@@ -69,12 +69,10 @@ export class CapacitorDeeplinking {
       app.setAsDefaultProtocolClient(this.deeplinkingOptions.customProtocol);
     }
 
-    app.on("will-finish-launching", () => {
-      app.on("open-url", (event, url) => {
-        event.preventDefault();
-        this.passedDeeplinkingUrl = url;
-        this.internalDeeplinkHandler(url);
-      });
+    app.on("open-url", (event, url) => {
+      event.preventDefault();
+      this.passedDeeplinkingUrl = url;
+      this.internalDeeplinkHandler(url);
     });
 
     if (process.platform == "win32") {


### PR DESCRIPTION
With the `open-url` callback was not being fired when inside the `will-finish-launching` callback. My theory is that the `will-finish-launching` event was already fired before this code was run preventing the `open-url` callback from working.

According to the Electron docs (https://www.electronjs.org/docs/api/app#event-will-finish-launching) it is recommended that the `open-url` callback be registered after the `ready` event has fired. The `CapacitorElectronApp.init` method is run inside the `ready` handler here: https://github.com/capacitor-community/electron/blob/main/packages/platform/template/src/index.ts#L11 which in turn runs the `ElectronDeepLinking.init` code here: https://github.com/capacitor-community/electron/blob/main/packages/core/src/electron/CapacitorElectronApp.ts#L162 so I believe this will have no ill impacts across platforms.

This spawned out of #36.