### PR TITLE
Add the `LocalNotifications` plugin.

### DIFF
--- a/packages/core/src/plugins/electron/local-notifications.ts
+++ b/packages/core/src/plugins/electron/local-notifications.ts
@@ -1,0 +1,71 @@
+import {
+  LocalNotificationsPluginWeb,
+  WebPlugin,
+  LocalNotificationsPlugin,
+  NotificationChannel,
+  LocalNotification,
+  LocalNotificationScheduleResult,
+  LocalNotificationActionType,
+  LocalNotificationPendingList,
+  NotificationChannelList,
+  LocalNotificationEnabledResult,
+  NotificationPermissionResponse,
+} from "@capacitor/core";
+
+export class LocalNotificationsPluginElectron extends WebPlugin
+  implements LocalNotificationsPlugin {
+  localNotificationsPluginWeb: LocalNotificationsPlugin;
+
+  constructor() {
+    super({
+      name: "LocalNotifications",
+      platforms: ["electron"],
+    });
+
+    this.localNotificationsPluginWeb = new LocalNotificationsPluginWeb();
+  }
+
+  schedule(options: {
+    notifications: LocalNotification[];
+  }): Promise<LocalNotificationScheduleResult> {
+    return this.localNotificationsPluginWeb.schedule(options);
+  }
+
+  getPending(): Promise<LocalNotificationPendingList> {
+    return this.localNotificationsPluginWeb.getPending();
+  }
+
+  registerActionTypes(options: {
+    types: LocalNotificationActionType[];
+  }): Promise<void> {
+    return this.localNotificationsPluginWeb.registerActionTypes(options);
+  }
+
+  cancel(pending: LocalNotificationPendingList): Promise<void> {
+    return this.localNotificationsPluginWeb.cancel(pending);
+  }
+
+  areEnabled(): Promise<LocalNotificationEnabledResult> {
+    return this.localNotificationsPluginWeb.areEnabled();
+  }
+
+  createChannel(channel: NotificationChannel): Promise<void> {
+    return this.localNotificationsPluginWeb.createChannel(channel);
+  }
+
+  deleteChannel(channel: NotificationChannel): Promise<void> {
+    return this.localNotificationsPluginWeb.deleteChannel(channel);
+  }
+
+  listChannels(): Promise<NotificationChannelList> {
+    return this.localNotificationsPluginWeb.listChannels();
+  }
+
+  requestPermission(): Promise<NotificationPermissionResponse> {
+    return this.localNotificationsPluginWeb.requestPermission();
+  }
+}
+
+const LocalNotifications = new LocalNotificationsPluginElectron();
+
+export { LocalNotifications };

--- a/packages/core/src/plugins/plugins.ts
+++ b/packages/core/src/plugins/plugins.ts
@@ -5,10 +5,10 @@ export * from "./electron/app";
 export * from "./electron/clipboard";
 export * from "./electron/device";
 export * from "./electron/filesystem";
+export * from "./electron/local-notifications";
 export * from "./electron/modals";
 export * from "./electron/network";
 export * from "./electron/splashscreen";
-export * from "./electron/local-notifications";
 
 mergeWebPlugins(Plugins);
 

--- a/packages/core/src/plugins/plugins.ts
+++ b/packages/core/src/plugins/plugins.ts
@@ -8,6 +8,7 @@ export * from "./electron/filesystem";
 export * from "./electron/modals";
 export * from "./electron/network";
 export * from "./electron/splashscreen";
+export * from "./electron/local-notifications";
 
 mergeWebPlugins(Plugins);
 


### PR DESCRIPTION
 Use the `LocalNotificationsPluginWeb` implementation since it's using the HTML5 notifications API which Electron supports.

@IT-MikeS -- Do you have a documented process for testing plugins? I tried using `npm link` with a local project but that didn't work. Thanks!