### PR TITLE
Define typeRoots

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "outDir": "./build",
     "target": "ES5",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "typeRoots": ["./node_modules/@types"]
   }
 }


### PR DESCRIPTION
Hello,

My main project is using TypeScript and the command `tsc` launched by this library was trying to compile my own `node_modules/@types` folder (the parent one). This is the default behaviour of the TypeScript compiler and I think in the scope of this project it's not wanted and can introduce unexpected behaviours. In my case it failed to compile as I have invalid `@types` in my main `node_modules` folder.

To fix this issue I just added the `typeRoots` option that scopes the types search to the template's folder. 👍