### PR TITLE
Revert to electron ~10.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Capacitor community support for the Electron platform.
   <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 <a href="#contributors"><img src="https://img.shields.io/badge/all%20contributors-8-orange?style=flat-square" /></a>
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
-  <a href="https://www.electronjs.org/releases/stable?version=9"><img src="https://img.shields.io/badge/supported%20electron%20version-^11.0.1-blue?style=flat-square" /></a>
+  <a href="https://www.electronjs.org/releases/stable?version=9"><img src="https://img.shields.io/badge/supported%20electron%20version-~10.3.1-blue?style=flat-square" /></a>
 </p>
 <p align="center">
   <a href="https://npmjs.com/package/@capacitor-community/electron"><img src="https://img.shields.io/npm/v/@capacitor-community/electron.svg?style=flat-square" /></a>

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
     "@capacitor-community/electron": "^1.3.1"
   },
   "devDependencies": {
-    "electron": "^11.0.1",
+    "electron": "~10.3.1",
     "electron-builder": "^22.9.1",
     "typescript": "~4.0.5"
   },


### PR DESCRIPTION
11+ has an issue that can cause content to not be displayed on launch when using the splashscreen functions, until this is resolve from electrons side, to prevent user frustration the platform will now use the v10