### PR TITLE
Prefix icon with `assets/` so `electron-builder` can find it.

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -40,11 +40,11 @@
     "mac": {
       "category": "public.app-category.developer-tools",
       "target": "dmg",
-      "icon": "appIcon.png"
+      "icon": "assets/appIcon.png"
     },
     "win": {
       "target": "nsis",
-      "icon": "appIcon.ico"
+      "icon": "assets/appIcon.ico"
     }
   }
 }


### PR DESCRIPTION
When testing v3 I realized my icon wasn't being used even when I replaced it. This prefixes the icon with `assets/` so `electron-builder` can find it.