### PR TITLE
Add type roots on tsconfig.json

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -8,6 +8,7 @@
     "module": "CommonJS",
     "moduleResolution": "node",
     "esModuleInterop": true,
+    "typeRoots": ["./node_modules/@types"],
     "allowJs": true,
     "rootDir": "."
   }


### PR DESCRIPTION
PR #69 did the same thing, but missing on current repo.
Just added `typeRoots` to `tsconfig.json`.
