### PR TITLE
Expose backgroundColor from config

### DIFF
--- a/docs/config-options/index.md
+++ b/docs/config-options/index.md
@@ -1,12 +1,13 @@
 # **Config Options**
 
-You can use the below options in the `capacitor.config` file under the `electron` prop. All options are optional and can be omitted if you do not require them. Further you can edit and tinker with the `electron/src/index.ts` file as more is exposed to the developer as of V3.
-
-<br />
+You can use the options below in the `capacitor.config.ts` file under the `electron` prop. Please use ``ElectronCapacitorConfig`` exported from ``@capacitor-community/electron`` instead of ``CapacitorConfig`` from ``@capacitor/cli``.\
+All options are optional and can be omitted if you do not require them.\
+Furthermore, you can edit and tinker with the `electron/src/index.ts` file as more is exposed to the developer as of V3.
 
 ```typescript
-...
-const config = {
+import { ElectronCapacitorConfig } from '@capacitor-community/electron';
+
+const config: ElectronCapacitorConfig = {
   ...,
   electron: {
     // Custom scheme for your app to be served on in the electron window.
@@ -17,13 +18,15 @@ const config = {
     splashScreenEnabled: false,
     // Custom image name in the electron/assets folder to use as splash image (.gif included)
     splashScreenImageName: 'splash.png',
-    // Switch on/off if the main window should be hidden until brought to the front by the tray menu, ect.
+    // Switch on/off if the main window should be hidden until brought to the front by the tray menu, etc.
     hideMainWindowOnLaunch: false,
     // Switch on/off whether or not to use deeplinking in your app.
     deepLinkingEnabled: false,
     // Custom protocol to be used with deeplinking for your app.
     deepLinkingCustomProtocol: 'mycapacitorapp',
   },
+  ...
 };
-...
+
+export default config;
 ```

--- a/docs/config-options/index.md
+++ b/docs/config-options/index.md
@@ -1,7 +1,7 @@
 # **Config Options**
 
-You can use the options below in the `capacitor.config.ts` file under the `electron` prop. Please use ``ElectronCapacitorConfig`` exported from ``@capacitor-community/electron`` instead of ``CapacitorConfig`` from ``@capacitor/cli``.\
-All options are optional and can be omitted if you do not require them.\
+You can use the options below in the `capacitor.config.ts` file under the `electron` prop. Please use `ElectronCapacitorConfig` exported from `@capacitor-community/electron` instead of `CapacitorConfig` from `@capacitor/cli`.\
+All options are optional and can be omitted if you do not require them. The `backgroundColor` property will also be used to configure the Electron window color.\
 Furthermore, you can edit and tinker with the `electron/src/index.ts` file as more is exposed to the developer as of V3.
 
 ```typescript
@@ -11,7 +11,7 @@ const config: ElectronCapacitorConfig = {
   ...,
   electron: {
     // Custom scheme for your app to be served on in the electron window.
-    customUrlScheme: 'capacitor-electron', 
+    customUrlScheme: 'capacitor-electron',
     // Switch on/off a tray icon and menu, which is customizable in the app.
     trayIconAndMenuEnabled: false,
     // Switch on/off whether or not a splashscreen will be used.

--- a/src/electron/definitions.ts
+++ b/src/electron/definitions.ts
@@ -21,4 +21,10 @@ export interface CapacitorElectronConfig {
   deepLinkingCustomProtocol?: string;
 }
 
+export interface CapacitorElectronExtendedConfig extends CapacitorElectronConfig {
+  backgroundColor?: string;
+  appId?: string;
+  appName?: string;
+}
+
 export type ElectronCapacitorConfig = CapacitorConfig & { electron: CapacitorElectronConfig }

--- a/src/electron/definitions.ts
+++ b/src/electron/definitions.ts
@@ -1,3 +1,5 @@
+import { CapacitorConfig } from "@capacitor/cli";
+
 export interface SplashOptions {
   imageFilePath?: string;
   windowWidth?: number;
@@ -18,3 +20,5 @@ export interface CapacitorElectronConfig {
   deepLinkingEnabled?: boolean;
   deepLinkingCustomProtocol?: string;
 }
+
+export type ElectronCapacitorConfig = CapacitorConfig & { electron: CapacitorElectronConfig }


### PR DESCRIPTION
Uses https://github.com/capacitor-community/electron/pull/126

This pull-request makes it so that the ``getCapacitorConfig`` function also returns the ``backgroundColor`` from the general Capacitor config, so it can be used in the ``MainWindow`` configuration.

The template code was also updated to set the background color from the config.