### PR TITLE
Use Buffer.from instead of new Buffer

### DIFF
--- a/src/electron/util.ts
+++ b/src/electron/util.ts
@@ -144,7 +144,7 @@ export async function encodeFromFile(filePath: string): Promise<string> {
   mediaType = /\//.test(mediaType) ? mediaType : "image/" + mediaType;
   let dataBase64 = Buffer.isBuffer(fileData)
     ? fileData.toString("base64")
-    : new Buffer(fileData).toString("base64");
+    : Buffer.from(fileData).toString("base64");
   return "data:" + mediaType + ";base64," + dataBase64;
 }
 


### PR DESCRIPTION
`new Buffer` has been [deprecated](https://nodejs.org/api/buffer.html#buffer_new_buffer_string_encoding) since NodeJS version 6, `Buffer.from` should be used instead.