### PR TITLE
Bugfix: new class instance for every request

### DIFF
--- a/src/electron/util.ts
+++ b/src/electron/util.ts
@@ -93,6 +93,7 @@ export function setupCapacitorElectronPlugins() {
   const AsyncFunction = (async () => {}).constructor;
   const plugins: any = require(rtPluginsPath)
   const pluginFunctionsRegistry: any = {}
+  const pluginInstanceRegistry: Record<string, any> = {};
   for (const pluginKey of Object.keys(plugins)) {
     console.log(pluginKey)
     for (const classKey of Object.keys(plugins[pluginKey]).filter(
@@ -103,6 +104,7 @@ export function setupCapacitorElectronPlugins() {
       console.log('    ' + JSON.stringify(functionList))
       console.log('')
       if (!pluginFunctionsRegistry[classKey]) {
+        pluginInstanceRegistry[classKey] = new plugins[pluginKey][classKey]();
         pluginFunctionsRegistry[classKey] = {}
       }
       for (const functionName of functionList) {
@@ -110,7 +112,7 @@ export function setupCapacitorElectronPlugins() {
           pluginFunctionsRegistry[classKey][functionName] = ipcMain.on(`${classKey}-${functionName}`, async (event, ...args) => {
             console.log('args')
             console.log(args)
-            const pluginRef = new plugins[pluginKey][classKey]()
+            const pluginRef = pluginInstanceRegistry[classKey];
             const theCall = pluginRef[functionName]
             console.log('theCall')
             console.log(theCall)

--- a/src/runtime/electron-rt.ts
+++ b/src/runtime/electron-rt.ts
@@ -157,6 +157,7 @@ addPlatform("electron", {
 });
 setPlatform("electron");
 const pluginsRegistry: any = {};
+const pluginInstanceRegistry: Record<string, any> = {};
 const AsyncFunction = (async () => {}).constructor;
 for (const pluginKey of Object.keys(plugins)) {
   for (const classKey of Object.keys(plugins[pluginKey]).filter(
@@ -166,11 +167,12 @@ for (const pluginKey of Object.keys(plugins)) {
       plugins[pluginKey][classKey].prototype
     ).filter((v) => v !== "constructor");
     if (!pluginsRegistry[classKey]) {
+      pluginInstanceRegistry[classKey] = new plugins[pluginKey][classKey]();
       pluginsRegistry[classKey] = {};
     }
     for (const functionName of functionList) {
       if (!pluginsRegistry[classKey][functionName]) {
-        const pluginRef = new plugins[pluginKey][classKey]();
+        const pluginRef = pluginInstanceRegistry[classKey];
         const isPromise =
           pluginRef[functionName] instanceof Promise ||
           pluginRef[functionName] instanceof AsyncFunction;


### PR DESCRIPTION
We have a plugin that keeps track of messages by issuing IDs and storing them in an object on the class. This didn't work with the current system because a new class instance would be created for every call which meant that the object would always be empty and the ID would never match.

This pull-request fixes this issue by creating one instance of a class and calling the appropriate method when a request is made.