### PR TITLE
Bugfix: Match response for promises

### DIFF
--- a/src/electron/util.ts
+++ b/src/electron/util.ts
@@ -108,26 +108,25 @@ export function setupCapacitorElectronPlugins() {
       for (const functionName of functionList) {
         if (!pluginFunctionsRegistry[classKey][functionName]) {
           pluginFunctionsRegistry[classKey][functionName] = ipcMain.on(`${classKey}-${functionName}`, async (event, id, ...args) => {
-              console.log('args')
-              console.log(args)
-              const pluginRef = new plugins[pluginKey][classKey]();
-              const theCall = pluginRef[functionName];
-              console.log("theCall");
-              console.log(theCall);
-              const isPromise =
-                theCall instanceof Promise || theCall instanceof AsyncFunction;
-              console.log("isPromise");
-              console.log(isPromise);
-              let returnVal = null;
-              if (isPromise) {
-                returnVal = await theCall(...args);
-                event.reply(`${classKey}-${functionName}-reply`, id, returnVal || null);
-              } else {
-                returnVal = theCall(...args);
-                event.returnValue = returnVal;
-              }
+            console.log('args')
+            console.log(args)
+            const pluginRef = new plugins[pluginKey][classKey]();
+            const theCall = pluginRef[functionName];
+            console.log("theCall");
+            console.log(theCall);
+            const isPromise =
+              theCall instanceof Promise || theCall instanceof AsyncFunction;
+            console.log("isPromise");
+            console.log(isPromise);
+            let returnVal = null;
+            if (isPromise) {
+              returnVal = await theCall(...args);
+              event.reply(`${classKey}-${functionName}-reply`, id, returnVal || null);
+            } else {
+              returnVal = theCall(...args);
+              event.returnValue = returnVal;
             }
-          );
+          });
         }
       }
     }

--- a/src/electron/util.ts
+++ b/src/electron/util.ts
@@ -107,25 +107,27 @@ export function setupCapacitorElectronPlugins() {
       }
       for (const functionName of functionList) {
         if (!pluginFunctionsRegistry[classKey][functionName]) {
-          pluginFunctionsRegistry[classKey][functionName] = ipcMain.on(`${classKey}-${functionName}`, async (event, ...args) => {
-            console.log('args')
-            console.log(args)
-            const pluginRef = new plugins[pluginKey][classKey]()
-            const theCall = pluginRef[functionName]
-            console.log('theCall')
-            console.log(theCall)
-            const isPromise = theCall instanceof Promise || (theCall instanceof AsyncFunction)
-            console.log('isPromise')
-            console.log(isPromise)
-            let returnVal = null
-            if (isPromise) {
-              returnVal = await theCall(...args)
-              event.reply(`${classKey}-${functionName}-reply`, returnVal || null)
-            } else {
-              returnVal = theCall(...args)
-              event.returnValue = returnVal
+          pluginFunctionsRegistry[classKey][functionName] = ipcMain.on(`${classKey}-${functionName}`, async (event, id, ...args) => {
+              console.log('args')
+              console.log(args)
+              const pluginRef = new plugins[pluginKey][classKey]();
+              const theCall = pluginRef[functionName];
+              console.log("theCall");
+              console.log(theCall);
+              const isPromise =
+                theCall instanceof Promise || theCall instanceof AsyncFunction;
+              console.log("isPromise");
+              console.log(isPromise);
+              let returnVal = null;
+              if (isPromise) {
+                returnVal = await theCall(...args);
+                event.reply(`${classKey}-${functionName}-reply`, id, returnVal || null);
+              } else {
+                returnVal = theCall(...args);
+                event.returnValue = returnVal;
+              }
             }
-          })
+          );
         }
       }
     }

--- a/src/electron/util.ts
+++ b/src/electron/util.ts
@@ -130,7 +130,7 @@ export function setupCapacitorElectronPlugins() {
             console.log('isPromise')
             console.log(isPromise)
             if (isPromise) {
-              event.reply(`${classKey}-${functionName}-reply`, (await call) ?? null)
+              event.reply(`${classKey}-${functionName}-reply`, id, (await call) ?? null)
             } else {
               event.returnValue = call;
             }


### PR DESCRIPTION
We ran into issues where responses would be returned to the wrong request if multiple request were made before the first had finished.

This pull-request should solve this by creating a random ID for every method call and matching that against the response.