### PR TITLE
Expose config to plugins

### DIFF
--- a/docs-site/docs/creatingplugins.md
+++ b/docs-site/docs/creatingplugins.md
@@ -110,3 +110,23 @@ sidebar_position: 5
 
 
 ### Check out the `plugin-example` folder in the repo for a small demo plugin.
+
+## Config
+Plugins get access to the `capacitor.config.ts` config object as the first argument to the constructor. E.g.:
+```typescript
+export default class App {
+  private config?: Record<string, any>;
+
+  constructor(config?: Record<string, any>) {
+    this.config = config;
+  }
+
+  getLaunchUrl(): string | undefined {
+    const url = this.config?.server?.url;
+    
+    return url ? { url } : undefined;
+  }
+}
+```
+
+**Keep in mind that the config could possibly be `undefined`.**

--- a/platform/src/electron/util.ts
+++ b/platform/src/electron/util.ts
@@ -9,6 +9,7 @@ import { join } from 'path';
 import type { CapacitorElectronConfig } from './definitions';
 
 class CapElectronEmitter extends EventEmitter {}
+let config: CapacitorElectronConfig = {};
 
 export const CapElectronEventEmitter = new CapElectronEmitter();
 
@@ -103,7 +104,7 @@ export function setupCapacitorElectronPlugins(): void {
             pluginInstances[`${pluginKey}_${classKey}`] === undefined ||
             pluginInstances[`${pluginKey}_${classKey}`] === null
           ) {
-            pluginInstances[`${pluginKey}_${classKey}`] = new plugins[pluginKey][classKey]();
+            pluginInstances[`${pluginKey}_${classKey}`] = new plugins[pluginKey][classKey](config);
           }
           pluginRef = pluginInstances[`${pluginKey}_${classKey}`];
           const isPromise =
@@ -139,7 +140,6 @@ export async function encodeFromFile(filePath: string): Promise<string> {
 }
 
 export function getCapacitorElectronConfig(): CapacitorElectronConfig {
-  let config: CapacitorElectronConfig = {};
   let capFileConfig: any = {};
   if (existsSync(join(app.getAppPath(), 'build', 'capacitor.config.js'))) {
     capFileConfig = require(join(app.getAppPath(), 'build', 'capacitor.config.js')).default;


### PR DESCRIPTION
In order for a plugin to replicate the [`App.getLaunchUrl`](https://capacitorjs.com/docs/apis/app#applaunchurl) function for Electron it needs to have access to the config.
This pull-request adds the config to the constructor of a plugin. It can access it like so:
```typescript
export default class App {
  private config?: Record<string, any>;

  constructor(config?: Record<string, any>) {
    this.config = config;
  }

  getLaunchUrl(): string | undefined {
    const url = this.config?.server?.url;
    
    return url ? { url } : undefined;
  }
}
```