### PR TITLE
Fix bad reference to ElectronCapacitorConfig in the docs.

### DIFF
--- a/docs-site/docs/configoptions.md
+++ b/docs-site/docs/configoptions.md
@@ -4,14 +4,14 @@ sidebar_position: 4
 
 # Config Options
 
-You can use the options below in the `capacitor.config.ts` file under the `electron` prop. Please use `ElectronCapacitorConfig` exported from `@capacitor-community/electron` instead of `CapacitorConfig` from `@capacitor/cli`.\
+You can use the options below in the `capacitor.config.ts` file under the `electron` prop. Please use `CapacitorElectronConfig` exported from `@capacitor-community/electron` instead of `CapacitorConfig` from `@capacitor/cli`.\
 All options are optional and can be omitted if you do not require them. The `backgroundColor` property will also be used to configure the Electron window color.\
 Furthermore, you can edit and tinker with the `electron/src/index.ts` file as more is exposed to the developer as of V3.
 
 ```typescript
-import { ElectronCapacitorConfig } from '@capacitor-community/electron';
+import { CapacitorElectronConfig } from '@capacitor-community/electron';
 
-const config: ElectronCapacitorConfig = {
+const config: CapacitorElectronConfig = {
   ...,
   electron: {
     // Custom scheme for your app to be served on in the electron window.


### PR DESCRIPTION
I noticed this today while setting up my build. The export is actually called `CapacitorElectronConfig` but the docs reference `ElectronCapacitorConfig`.

There appears to be a build directory committed (`/docs`) that needs to be updated as well. I have a commit that does this, but I've withheld it from the PR. Wasn't sure if you gated the actual generated docs or not... Looks like building on my machine may cause artifacts in unexpected docs files.

LMK if you want me to build the docs and add them into this PR, and I will.