### PR TITLE
Fix typo in setup.ts

### DIFF
--- a/platform/template/src/setup.ts
+++ b/platform/template/src/setup.ts
@@ -165,7 +165,7 @@ export class ElectronCapacitorApp {
     // Setup the main manu bar at the top of our window.
     Menu.setApplicationMenu(Menu.buildFromTemplate(this.AppMenuBarMenuTemplate));
 
-    // If the splashscreen is enabled, show it first while the main window loads then dwitch it out for the main window, or just load the main window from the start.
+    // If the splashscreen is enabled, show it first while the main window loads then switch it out for the main window, or just load the main window from the start.
     if (this.CapacitorFileConfig.electron?.splashScreenEnabled) {
       this.SplashScreen = new CapacitorSplashScreen({
         imageFilePath: join(


### PR DESCRIPTION
Fixes `dwitch` to `switch` in the template's `setup.ts` file