### PR TITLE
add support for includePlugins in capacitor config

### DIFF
--- a/src/electron-platform-template/tsconfig.json
+++ b/src/electron-platform-template/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "outDir": "./build",
     "importHelpers": true,
+    "skipLibCheck": true,
     "target": "ES2017",
     "module": "CommonJS",
     "moduleResolution": "node",


### PR DESCRIPTION
the `includePlugins` directive is a plugin whitelist already supported by the `android` and `ios` platforms. (see https://capacitorjs.com/docs/config#schema)

Note that most of the `loadConfig*` functions are from the [config file](https://github.com/ionic-team/capacitor/blob/3abdbed38844d5d59d244f6f0dfc2647f29ce446/cli/src/config.ts#L167) of the capacitor project itself.
They are unfortunately not exported so importing them manually is required.