### PR TITLE
feat: call context

### DIFF
--- a/docs-site/docs/creatingplugins.md
+++ b/docs-site/docs/creatingplugins.md
@@ -162,3 +162,24 @@ export default class App {
 ```
 
 **Keep in mind that the config could possibly be `undefined`.**
+
+## Caller
+Plugins get access to the caller of the method using the context object that gets passed as the second argument of the constructor. E.g.:
+
+```typescript
+import { PluginContext } from '@capacitor/electron';
+
+export default class App {
+  private context: PluginContext;
+
+  constructor(_?: Record<string, any>, context: PluginContext) {
+    this.context = context;
+  }
+
+  getId(): number {
+    const { sender } = this.context.caller.get();
+
+    return sender.id;
+  }
+}
+```

--- a/src/electron-platform/definitions.ts
+++ b/src/electron-platform/definitions.ts
@@ -1,4 +1,5 @@
 import type { CapacitorConfig } from '@capacitor/cli';
+import type { WebContents, WebFrameMain, IpcMainInvokeEvent } from 'electron';
 
 export interface SplashOptions {
   imageFilePath?: string;
@@ -26,4 +27,21 @@ export interface ElectronConfig {
 
 export type CapacitorElectronConfig = CapacitorConfig & {
   electron?: ElectronConfig;
+};
+
+export type PluginContext = {
+  caller: { readonly get: () => CallContext };
+};
+
+export type CallContext = {
+  /** The internal ID of the renderer process that sent this message */
+  processId: number;
+  /** The ID of the renderer frame that sent this message */
+  frameId: number;
+  /** Returns the `webContents` that sent the message */
+  sender: WebContents;
+  /** The frame that sent this message */
+  senderFrame: WebFrameMain;
+  /** The raw `IpcMainInvokeEvent`  */
+  event: IpcMainInvokeEvent;
 };


### PR DESCRIPTION
Previously you couldn't distinguish between windows when a method on a plugin was called. This PR gives plugins access to the caller window details.